### PR TITLE
ignore tagliatelle linter in network.go

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -25,7 +25,7 @@ var ErrInvalidRange = errors.New("range bounds are invalid, start is greater tha
 // address, a serial number, model, and ports.
 type Switch struct {
 	zebra.BaseResource
-	ManagementIP net.IP `json:"managementIp"`
+	ManagementIP net.IP `json:"managementIP"` //nolint:tagliatelle
 	SerialNumber string `json:"serialNumber"`
 	Model        string `json:"model"`
 	NumPorts     uint32 `json:"numPorts"`


### PR DESCRIPTION
previous error message for managementIP json tag resolved by ignoring tagliatelle linter

Signed-off-by: Shravya Nandyala <shravya.nandyala@gmail.com>