### PR TITLE
compute resources added

### DIFF
--- a/compute/compute.go
+++ b/compute/compute.go
@@ -1,0 +1,119 @@
+// Package compute provides structs and functions pertaining to compute resources.
+package compute
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/rchamarthy/zebra"
+)
+
+var ErrSerialEmpty = errors.New("serial number is nil")
+
+var ErrIPEmpty = errors.New("ip address is nil")
+
+var ErrModelEmpty = errors.New("model is empty")
+
+var ErrESXEmpty = errors.New("ESX id is empty")
+
+var ErrVCenterEmpty = errors.New("VCenter id is empty")
+
+var ErrServerIDEmtpy = errors.New("server id is empty")
+
+// A Server represents a server with credentials, a serial number, board IP, and
+// model information.
+type Server struct {
+	zebra.NamedResource
+	Credentials  zebra.Credentials `json:"credentials"`
+	SerialNumber string            `json:"serialNumber"`
+	BoardIP      net.IP            `json:"boardIP"` //nolint:tagliatelle
+	Model        string            `json:"model"`
+}
+
+func (s *Server) Validate(ctx context.Context) error {
+	switch {
+	case s.SerialNumber == "":
+		return ErrSerialEmpty
+	case s.BoardIP == nil:
+		return ErrIPEmpty
+	case s.Model == "":
+		return ErrModelEmpty
+	}
+
+	if err := s.Credentials.Validate(ctx); err != nil {
+		return err
+	}
+
+	return s.NamedResource.Validate(ctx)
+}
+
+// An ESX represents an ESX server with credentials, an associated server, and IP.
+type ESX struct {
+	zebra.NamedResource
+	Credentials zebra.Credentials `json:"credentials"`
+	ServerID    string            `json:"serverID"` //nolint:tagliatelle
+	IP          net.IP            `json:"ip"`
+}
+
+func (e *ESX) Validate(ctx context.Context) error {
+	if e.IP == nil {
+		return ErrIPEmpty
+	}
+
+	if e.ServerID == "" {
+		return ErrServerIDEmtpy
+	}
+
+	if credentialsErr := e.Credentials.Validate(ctx); credentialsErr != nil {
+		return credentialsErr
+	}
+
+	return e.NamedResource.Validate(ctx)
+}
+
+// A VCenter has credentials and an IP.
+type VCenter struct {
+	zebra.NamedResource
+	Credentials zebra.Credentials `json:"credentials"`
+	IP          net.IP            `json:"ip"`
+}
+
+func (v *VCenter) Validate(ctx context.Context) error {
+	if v.IP == nil {
+		return ErrIPEmpty
+	}
+
+	if err := v.Credentials.Validate(ctx); err != nil {
+		return err
+	}
+
+	return v.NamedResource.Validate(ctx)
+}
+
+// A VM is represented by a set of credentials, associated ESX ID, management IP,
+// and VCenterID.
+type VM struct {
+	zebra.NamedResource
+	Credentials  zebra.Credentials `json:"credentials"`
+	ESXID        string            `json:"esxID"`        //nolint:tagliatelle
+	ManagementIP net.IP            `json:"managementIP"` //nolint:tagliatelle
+	VCenterID    string            `json:"vCenterID"`    //nolint:tagliatelle
+}
+
+func (v *VM) Validate(ctx context.Context) error {
+	switch {
+	case v.ESXID == "":
+		return ErrESXEmpty
+	case v.ManagementIP == nil:
+		return ErrIPEmpty
+	case v.VCenterID == "":
+		return ErrVCenterEmpty
+	}
+
+	if err := v.Credentials.Validate(ctx); err != nil {
+		return err
+	}
+
+	return v.NamedResource.Validate(ctx)
+}

--- a/compute/compute_test.go
+++ b/compute/compute_test.go
@@ -1,0 +1,131 @@
+// Package compute_test tests structs and functions pertaining to compute resources
+// outlined in the compute package.
+package compute_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/rchamarthy/zebra/compute"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServer(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	ctx := context.Background()
+
+	server := new(compute.Server)
+	assert.NotNil(server.Validate(ctx))
+
+	server.ID = "hello"
+	server.Name = "there"
+	assert.NotNil(server.Validate(ctx))
+
+	server.SerialNumber = "a"
+	assert.NotNil(server.Validate(ctx))
+
+	server.BoardIP = net.ParseIP("10.1.0.0")
+	assert.NotNil(server.Validate(ctx))
+
+	server.Model = "b"
+	assert.NotNil(server.Validate(ctx))
+
+	server.Credentials.Name = "c"
+	server.Credentials.ID = "d"
+	server.Credentials.Keys = make(map[string]string)
+	server.Credentials.Keys["password"] = "e"
+	assert.NotNil(server.Validate(ctx))
+
+	server.Credentials.Keys["password"] = "actualPassw0rd%9"
+	assert.Nil(server.Validate(ctx))
+}
+
+func TestESX(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	ctx := context.Background()
+
+	esx := new(compute.ESX)
+	assert.NotNil(esx.Validate(ctx))
+
+	esx.ID = "rolling in the deep"
+	esx.Name = "adele"
+	assert.NotNil(esx.Validate(ctx))
+
+	esx.IP = net.ParseIP("10.1.0.0")
+	assert.NotNil(esx.Validate(ctx))
+
+	esx.ServerID = "server id"
+	assert.NotNil(esx.Validate(ctx))
+
+	esx.Credentials.Name = "k"
+	esx.Credentials.ID = "l"
+	esx.Credentials.Keys = make(map[string]string)
+	esx.Credentials.Keys["password"] = "m"
+	assert.NotNil(esx.Validate(ctx))
+
+	esx.Credentials.Keys["password"] = "actualPassw0rd%2"
+	assert.Nil(esx.Validate(ctx))
+}
+
+func TestVCenter(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	ctx := context.Background()
+
+	vcenter := new(compute.VCenter)
+	assert.NotNil(vcenter.Validate(ctx))
+
+	vcenter.ID = "blah"
+	vcenter.Name = "blahblah"
+	assert.NotNil(vcenter.Validate(ctx))
+
+	vcenter.IP = net.ParseIP("10.1.0.0")
+	assert.NotNil(vcenter.Validate(ctx))
+
+	vcenter.Credentials.Name = "n"
+	vcenter.Credentials.ID = "o"
+	vcenter.Credentials.Keys = make(map[string]string)
+	vcenter.Credentials.Keys["password"] = "p"
+	assert.NotNil(vcenter.Validate(ctx))
+
+	vcenter.Credentials.Keys["password"] = "actualPassw0rd%4"
+	assert.Nil(vcenter.Validate(ctx))
+}
+
+func TestVM(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	ctx := context.Background()
+
+	machine := new(compute.VM)
+	assert.NotNil(machine.Validate(ctx))
+
+	machine.ID = "can you hear me"
+	machine.Name = "you'd like to meet"
+	assert.NotNil(machine.Validate(ctx))
+
+	machine.ESXID = "q"
+	assert.NotNil(machine.Validate(ctx))
+
+	machine.ManagementIP = net.ParseIP("10.1.0.0")
+	assert.NotNil(machine.Validate(ctx))
+
+	machine.VCenterID = "r"
+	assert.NotNil(machine.Validate(ctx))
+
+	machine.Credentials.Name = "s"
+	machine.Credentials.ID = "t"
+	machine.Credentials.Keys = make(map[string]string)
+	machine.Credentials.Keys["password"] = "u"
+	assert.NotNil(machine.Validate(ctx))
+
+	machine.Credentials.Keys["password"] = "actualPassw0rd%1"
+	assert.Nil(machine.Validate(ctx))
+}

--- a/network/network.go
+++ b/network/network.go
@@ -25,10 +25,11 @@ var ErrInvalidRange = errors.New("range bounds are invalid, start is greater tha
 // address, a serial number, model, and ports.
 type Switch struct {
 	zebra.BaseResource
-	ManagementIP net.IP `json:"managementIP"` //nolint:tagliatelle
-	SerialNumber string `json:"serialNumber"`
-	Model        string `json:"model"`
-	NumPorts     uint32 `json:"numPorts"`
+	Credentials  zebra.Credentials `json:"credentials"`
+	ManagementIP net.IP            `json:"managementIP"` //nolint:tagliatelle
+	SerialNumber string            `json:"serialNumber"`
+	Model        string            `json:"model"`
+	NumPorts     uint32            `json:"numPorts"`
 }
 
 // Validate returns an error if the given Switch object has incorrect values.
@@ -43,6 +44,10 @@ func (s *Switch) Validate(ctx context.Context) error {
 		return ErrModelEmpty
 	case s.NumPorts == 0:
 		return ErrNumPortsEmpty
+	}
+
+	if err := s.Credentials.Validate(ctx); err != nil {
+		return err
 	}
 
 	return s.BaseResource.Validate(ctx)

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/rchamarthy/zebra"
 	"github.com/rchamarthy/zebra/network"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,6 +34,21 @@ func TestSwitch(t *testing.T) {
 	assert.NotNil(switch1.Validate(ctx))
 
 	switch1.NumPorts = 12
+	assert.NotNil(switch1.Validate(ctx))
+
+	switch1.Credentials = zebra.Credentials{
+		NamedResource: zebra.NamedResource{
+			BaseResource: zebra.BaseResource{
+				ID:     "blahblah",
+				Labels: nil,
+			},
+			Name: "blah",
+		},
+		Keys: nil,
+	}
+	assert.NotNil(switch1.Validate(ctx))
+
+	switch1.Credentials.Keys = make(map[string]string)
 	assert.Nil(switch1.Validate(ctx))
 }
 

--- a/resource_test.go
+++ b/resource_test.go
@@ -42,3 +42,47 @@ func TestNamedResource(t *testing.T) {
 	res.Name = "jasmine"
 	assert.Nil(res.Validate(ctx))
 }
+
+func TestCredentials(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	ctx := context.Background()
+
+	credentials := zebra.Credentials{
+		NamedResource: zebra.NamedResource{
+			BaseResource: zebra.BaseResource{ID: "", Labels: zebra.Labels{}},
+			Name:         "",
+		},
+		Keys: nil,
+	}
+	assert.NotNil(credentials.Validate(ctx))
+
+	credentials.ID = "id"
+	assert.NotNil(credentials.Validate(ctx))
+
+	credentials.Name = "name"
+	assert.NotNil(credentials.Validate(ctx))
+
+	credentials.Keys = make(map[string]string)
+	assert.Nil(credentials.Validate(ctx))
+
+	credentials.Keys["password"] = "a"
+	credentials.Keys["ssh-key"] = "test"
+	assert.NotNil(credentials.Validate(ctx))
+
+	credentials.Keys["password"] = "abcdefghijklm"
+	assert.NotNil(credentials.Validate(ctx))
+
+	credentials.Keys["password"] = "ABCDEFGHIJKLM"
+	assert.NotNil(credentials.Validate(ctx))
+
+	credentials.Keys["password"] = "ABCDEFghijklm"
+	assert.NotNil(credentials.Validate(ctx))
+
+	credentials.Keys["password"] = "ABCDEFghijklm1"
+	assert.NotNil(credentials.Validate(ctx))
+
+	credentials.Keys["password"] = "properPass123$"
+	assert.Nil(credentials.Validate(ctx))
+}


### PR DESCRIPTION
new package compute to model the following resources
- Server
- ESX
- VCenter
- VM

additionally, new type Credentials added in ze zebra package which contains:
- NamedResource
- Keys : maps[string]string to represent key-value pairs for authentication information

updated Switch to contain Credentials and updated test to reflect this change.

Fixes #15

Signed-off-by: Shravya Nandyala <shravya.nandyala@gmail.com>