### PR TITLE
added Type to BaseResource, removed GetName()

### DIFF
--- a/compute/compute_test.go
+++ b/compute/compute_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const Creds string = "Credentials"
+
 func TestServer(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
@@ -21,6 +23,7 @@ func TestServer(t *testing.T) {
 	assert.NotNil(server.Validate(ctx))
 
 	server.ID = "hello"
+	server.Type = "Server"
 	server.Name = "there"
 	assert.NotNil(server.Validate(ctx))
 
@@ -34,6 +37,7 @@ func TestServer(t *testing.T) {
 	assert.NotNil(server.Validate(ctx))
 
 	server.Credentials.Name = "c"
+	server.Credentials.Type = Creds
 	server.Credentials.ID = "d"
 	server.Credentials.Keys = make(map[string]string)
 	server.Credentials.Keys["password"] = "e"
@@ -53,6 +57,7 @@ func TestESX(t *testing.T) {
 	assert.NotNil(esx.Validate(ctx))
 
 	esx.ID = "rolling in the deep"
+	esx.Type = "ESX"
 	esx.Name = "adele"
 	assert.NotNil(esx.Validate(ctx))
 
@@ -64,6 +69,7 @@ func TestESX(t *testing.T) {
 
 	esx.Credentials.Name = "k"
 	esx.Credentials.ID = "l"
+	esx.Credentials.Type = Creds
 	esx.Credentials.Keys = make(map[string]string)
 	esx.Credentials.Keys["password"] = "m"
 	assert.NotNil(esx.Validate(ctx))
@@ -82,6 +88,7 @@ func TestVCenter(t *testing.T) {
 	assert.NotNil(vcenter.Validate(ctx))
 
 	vcenter.ID = "blah"
+	vcenter.Type = "VCenter"
 	vcenter.Name = "blahblah"
 	assert.NotNil(vcenter.Validate(ctx))
 
@@ -90,6 +97,7 @@ func TestVCenter(t *testing.T) {
 
 	vcenter.Credentials.Name = "n"
 	vcenter.Credentials.ID = "o"
+	vcenter.Credentials.Type = Creds
 	vcenter.Credentials.Keys = make(map[string]string)
 	vcenter.Credentials.Keys["password"] = "p"
 	assert.NotNil(vcenter.Validate(ctx))
@@ -108,6 +116,7 @@ func TestVM(t *testing.T) {
 	assert.NotNil(machine.Validate(ctx))
 
 	machine.ID = "can you hear me"
+	machine.Type = "VM"
 	machine.Name = "you'd like to meet"
 	assert.NotNil(machine.Validate(ctx))
 
@@ -121,6 +130,7 @@ func TestVM(t *testing.T) {
 	assert.NotNil(machine.Validate(ctx))
 
 	machine.Credentials.Name = "s"
+	machine.Credentials.Type = Creds
 	machine.Credentials.ID = "t"
 	machine.Credentials.Keys = make(map[string]string)
 	machine.Credentials.Keys["password"] = "u"

--- a/dc/dc_test.go
+++ b/dc/dc_test.go
@@ -21,6 +21,7 @@ func TestDatacenter(t *testing.T) {
 	assert.NotNil(datacenter.Validate(ctx))
 
 	datacenter.ID = "abracadabra"
+	datacenter.Type = "Datacenter"
 	datacenter.Name = "jasmine"
 	datacenter.Address = "1 palace st, agrabah"
 	assert.Nil(datacenter.Validate(ctx))
@@ -36,6 +37,7 @@ func TestRack(t *testing.T) {
 	assert.NotNil(rack.Validate(ctx))
 
 	rack.ID = "abracadabra"
+	rack.Type = "Rack"
 	rack.Name = "sher"
 	rack.Row = "bazar"
 	assert.Nil(rack.Validate(ctx))

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -24,6 +24,9 @@ func TestSwitch(t *testing.T) {
 	switch1.ID = "a"
 	assert.NotNil(switch1.Validate(ctx))
 
+	switch1.Type = "Switch"
+	assert.NotNil(switch1.Validate(ctx))
+
 	switch1.ManagementIP = net.ParseIP("10.1.0.0")
 	assert.NotNil(switch1.Validate(ctx))
 
@@ -40,6 +43,7 @@ func TestSwitch(t *testing.T) {
 		NamedResource: zebra.NamedResource{
 			BaseResource: zebra.BaseResource{
 				ID:     "blahblah",
+				Type:   "Credentials",
 				Labels: nil,
 			},
 			Name: "blah",
@@ -62,6 +66,7 @@ func TestIPAddressPool(t *testing.T) {
 	assert.NotNil(pool.Validate(ctx))
 
 	pool.ID = "a"
+	pool.Type = "IPAddressPool"
 	assert.Nil(pool.Validate(ctx))
 
 	ipnet := net.IPNet{IP: net.ParseIP("192.0.2.1"), Mask: nil}
@@ -92,6 +97,7 @@ func TestVLANPool(t *testing.T) {
 	assert.NotNil(pool.Validate(ctx))
 
 	pool.ID = "c"
+	pool.Type = "VLANPool"
 	pool.RangeStart = 10
 	pool.RangeEnd = 1
 	assert.NotNil(pool.Validate(ctx))

--- a/query/query.go
+++ b/query/query.go
@@ -100,19 +100,6 @@ func (qs *QueryStore) QueryType(types ...string) []zebra.Resource {
 	return resources
 }
 
-// Return resources with matching type and names.
-func (qs *QueryStore) QueryTypeName(resType string, names []string) []zebra.Resource {
-	resources := qs.QueryType(resType)
-	for i, res := range resources {
-		if !isIn(res.GetName(), names) {
-			resources[i] = resources[len(resources)-1]
-			resources = resources[:len(resources)-1]
-		}
-	}
-
-	return resources
-}
-
 // Return resources with all matching labels.
 func (qs *QueryStore) QueryLabelsMatchAll(queries []LabelQuery) ([]zebra.Resource, error) {
 	resources := make(map[string]zebra.Resource)

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/rchamarthy/zebra"
-	"github.com/rchamarthy/zebra/dc"
 	"github.com/rchamarthy/zebra/network"
 	"github.com/rchamarthy/zebra/query"
 	"github.com/stretchr/testify/assert"
@@ -135,30 +134,6 @@ func TestQueryType(t *testing.T) {
 	ippools := querystore.QueryType("IPAddressPool")
 	assert.True(len(ippools) == 1)
 	assert.True(ippools[0].GetID() == "0200000001")
-}
-
-func TestQueryTypeName(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
-
-	// Create Datacenter resource
-	resource1 := new(dc.Datacenter)
-	resource1.ID = "0100000001"
-	resource1.Name = "cisco-building-15"
-	resource1.Address = "blah blah san jose"
-
-	// Add resource to map
-	resources := make(map[string]zebra.Resource)
-	resources["0100000001"] = resource1
-
-	querystore := query.NewQueryStore(resources)
-	assert.NotNil(querystore)
-
-	results := querystore.QueryTypeName("Datacenter", []string{"cisco-building-14"})
-	assert.True(len(results) == 0)
-
-	results = querystore.QueryTypeName("Datacenter", []string{"cisco-building-14", "cisco-building-15"})
-	assert.True(len(results) == 1)
 }
 
 func TestInvalidLabelQuery(t *testing.T) {

--- a/resource.go
+++ b/resource.go
@@ -12,13 +12,15 @@ import (
 type Resource interface {
 	Validate(ctx context.Context) error
 	GetID() string
-	GetName() string
+	GetType() string
 	GetLabels() Labels
 }
 
 var ErrNameEmpty = errors.New("name is empty")
 
 var ErrIDEmpty = errors.New("id is empty")
+
+var ErrTypeEmpty = errors.New("type is empty")
 
 var ErrPassLen = errors.New("password is less than 12 characters long")
 
@@ -34,6 +36,7 @@ var ErrNoKeys = errors.New("keys is nil")
 // assigned an ID string.
 type BaseResource struct {
 	ID     string `json:"id"`
+	Type   string `json:"type"`
 	Labels Labels `json:"labels,omitempty"`
 }
 
@@ -42,6 +45,8 @@ type BaseResource struct {
 func (r *BaseResource) Validate(ctx context.Context) error {
 	if r.ID == "" {
 		return ErrIDEmpty
+	} else if r.Type == "" {
+		return ErrTypeEmpty
 	}
 
 	return nil
@@ -53,8 +58,8 @@ func (r *BaseResource) GetID() string {
 }
 
 // BaseResource has no name. Return empty string.
-func (r *BaseResource) GetName() string {
-	return ""
+func (r *BaseResource) GetType() string {
+	return r.Type
 }
 
 // Return labels of BaseResource r.
@@ -81,11 +86,6 @@ func (r *NamedResource) Validate(ctx context.Context) error {
 	}
 
 	return r.BaseResource.Validate(ctx)
-}
-
-// Return name of NamedResource r.
-func (r *NamedResource) GetName() string {
-	return r.Name
 }
 
 // Credentials represents a named resource that has a set of keys (where each key is

--- a/resource_test.go
+++ b/resource_test.go
@@ -16,14 +16,21 @@ func TestBaseResource(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
-	res := &zebra.BaseResource{ID: "", Labels: zebra.Labels{"key": "value"}}
+	res := &zebra.BaseResource{
+		ID:     "",
+		Type:   "",
+		Labels: zebra.Labels{"key": "value"},
+	}
 	assert.NotNil(res.Validate(ctx))
 
 	res.ID = "abracadabra"
+	assert.NotNil(res.Validate(ctx))
+
+	res.Type = "BaseResource"
 	assert.Nil(res.Validate(ctx))
 
-	assert.True(res.ID == res.GetID())
-	assert.True(res.GetName() == "")
+	assert.True(res.GetID() == res.ID)
+	assert.True(res.GetType() == res.Type)
 	assert.True(res.GetLabels().HasKey("key"))
 }
 
@@ -35,8 +42,12 @@ func TestNamedResource(t *testing.T) {
 
 	ctx := context.Background()
 	res := &zebra.NamedResource{
-		BaseResource: zebra.BaseResource{ID: "", Labels: zebra.Labels{"key": "value"}},
-		Name:         "",
+		BaseResource: zebra.BaseResource{
+			ID:     "",
+			Type:   "",
+			Labels: zebra.Labels{"key": "value"},
+		},
+		Name: "",
 	}
 	assert.NotNil(res.Validate(ctx))
 
@@ -44,9 +55,12 @@ func TestNamedResource(t *testing.T) {
 	assert.NotNil(res.Validate(ctx))
 	assert.True(res.GetID() == res.ID)
 
+	res.Type = "NamedResource"
+	assert.NotNil(res.Validate(ctx))
+	assert.True(res.GetType() == res.Type)
+
 	res.Name = "jasmine"
 	assert.Nil(res.Validate(ctx))
-	assert.True(res.GetName() == res.Name)
 
 	assert.True(res.GetLabels().HasKey("key"))
 }
@@ -59,14 +73,21 @@ func TestCredentials(t *testing.T) {
 
 	credentials := zebra.Credentials{
 		NamedResource: zebra.NamedResource{
-			BaseResource: zebra.BaseResource{ID: "", Labels: zebra.Labels{}},
-			Name:         "",
+			BaseResource: zebra.BaseResource{
+				ID:     "",
+				Type:   "Credentials",
+				Labels: zebra.Labels{},
+			},
+			Name: "",
 		},
 		Keys: nil,
 	}
 	assert.NotNil(credentials.Validate(ctx))
 
 	credentials.ID = "id"
+	assert.NotNil(credentials.Validate(ctx))
+
+	credentials.Type = "Credentials"
 	assert.NotNil(credentials.Validate(ctx))
 
 	credentials.Name = "name"

--- a/store.go
+++ b/store.go
@@ -1,0 +1,11 @@
+package zebra
+
+// Store interface requires basic store functionalities.
+type Store interface {
+	Initialize() error
+	Wipe() error
+	Clear() error
+	Load() (map[string]Resource, error)
+	Create(res Resource) error
+	Delete(res Resource) error
+}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2,7 +2,6 @@ package store_test
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/rchamarthy/zebra"
@@ -10,6 +9,8 @@ import (
 	"github.com/rchamarthy/zebra/store"
 	"github.com/stretchr/testify/assert"
 )
+
+const vlan string = "VLANPool"
 
 func TestInitialize(t *testing.T) {
 	t.Parallel()
@@ -32,14 +33,15 @@ func TestCreate(t *testing.T) {
 	// Create VLANPool resource
 	resource := new(network.VLANPool)
 	resource.ID = "0100000001"
+	resource.Type = vlan
 	resource.Labels = make(map[string]string)
 	resource.Labels["key"] = "value"
 	resource.RangeStart = 0
 	resource.RangeEnd = 10
 
-	types := make(map[string]zebra.Resource)
+	types := make(map[string]func() zebra.Resource)
 
-	types["VLANPool"] = new(network.VLANPool)
+	types[vlan] = func() zebra.Resource { return new(network.VLANPool) }
 
 	filestore := store.NewFileStore("teststore1", types)
 
@@ -63,13 +65,14 @@ func TestLoad(t *testing.T) {
 	// Create VLANPool resource
 	resource := new(network.VLANPool)
 	resource.ID = "0100000001"
+	resource.Type = vlan
 	resource.Labels = make(map[string]string)
 	resource.RangeStart = 0
 	resource.RangeEnd = 10
 
-	types := make(map[string]zebra.Resource)
+	types := make(map[string]func() zebra.Resource)
 
-	types["VLANPool"] = new(network.VLANPool)
+	types[vlan] = func() zebra.Resource { return new(network.VLANPool) }
 
 	filestore := store.NewFileStore("teststore2", types)
 
@@ -88,8 +91,7 @@ func TestLoad(t *testing.T) {
 
 	assert.True(resources != nil)
 	assert.True(resources["0100000001"] != nil)
-	assert.True(reflect.TypeOf(resources["0100000001"]).String() ==
-		"*network.VLANPool")
+	assert.True(resources["0100000001"].GetType() == vlan)
 }
 
 func TestDelete(t *testing.T) {
@@ -101,13 +103,14 @@ func TestDelete(t *testing.T) {
 	// Create VLANPool resource
 	resource := new(network.VLANPool)
 	resource.ID = "0100000001"
+	resource.Type = vlan
 	resource.Labels = make(map[string]string)
 	resource.RangeStart = 0
 	resource.RangeEnd = 10
 
-	types := make(map[string]zebra.Resource)
+	types := make(map[string]func() zebra.Resource)
 
-	types["VLANPool"] = new(network.VLANPool)
+	types[vlan] = func() zebra.Resource { return new(network.VLANPool) }
 
 	filestore := store.NewFileStore("teststore3", types)
 
@@ -137,6 +140,7 @@ func TestClearStore(t *testing.T) {
 	// Create first VLANPool resource
 	resource1 := new(network.VLANPool)
 	resource1.ID = "0100000001"
+	resource1.Type = vlan
 	resource1.Labels = make(map[string]string)
 	resource1.RangeStart = 0
 	resource1.RangeEnd = 10
@@ -144,13 +148,14 @@ func TestClearStore(t *testing.T) {
 	// Create second VLANPool resource
 	resource2 := new(network.VLANPool)
 	resource2.ID = "0200000001"
+	resource2.Type = vlan
 	resource2.Labels = make(map[string]string)
 	resource2.RangeStart = 0
 	resource2.RangeEnd = 10
 
-	types := make(map[string]zebra.Resource)
+	types := make(map[string]func() zebra.Resource)
 
-	types["VLANPool"] = new(network.VLANPool)
+	types[vlan] = func() zebra.Resource { return new(network.VLANPool) }
 
 	filestore := store.NewFileStore("teststore4", types)
 


### PR DESCRIPTION
1. added Type as a parameter for BaseResource
2. removed GetName() for Resource interface, added GetType()
3. removed reflect stuff, switched out for neater type map for FileStore which takes key string and value func() zebra.Resource to create a new resource without reflect
4. moved Store interface to zebra package
5. adjusted test files to work with changes
6. removed QueryTypeName() from query

Signed-off-by: Shravya Nandyala <shravya.nandyala@gmail.com>