### PR TITLE
added GET methods for rest api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/rchamarthy/zebra"
+	"github.com/rchamarthy/zebra/network"
+	"github.com/rchamarthy/zebra/query"
+	"github.com/rchamarthy/zebra/store"
+)
+
+//nolint:gochecknoglobals
+var (
+	Types      map[string]func() zebra.Resource
+	ResStore   *store.FileStore
+	QueryStore *query.QueryStore
+
+	ErrNumArgs = errors.New("wrong number of args")
+)
+
+// Set up store and query store given storage root.
+func SetUp(storageRoot string) error {
+	Types = map[string]func() zebra.Resource{
+		"VLANPool": func() zebra.Resource { return new(network.VLANPool) },
+	}
+	ResStore = store.NewFileStore(storageRoot, Types)
+
+	err := ResStore.Initialize()
+	if err != nil {
+		return err
+	}
+
+	resMap, err := ResStore.Load()
+	if err != nil {
+		return err
+	}
+
+	QueryStore = query.NewQueryStore(resMap)
+
+	err = QueryStore.Initialize()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetResources(writer http.ResponseWriter, req *http.Request) {
+	data := sortByType(QueryStore.Query())
+
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusCreated)
+
+	err := json.NewEncoder(writer).Encode(data)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func GetResourcesByID(writer http.ResponseWriter, req *http.Request) {
+	uuids := strings.Split(req.URL.Query().Get("id"), ",")
+	data := sortByType(QueryStore.QueryUUID(uuids))
+
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusCreated)
+
+	err := json.NewEncoder(writer).Encode(data)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func GetResourcesByType(writer http.ResponseWriter, req *http.Request) {
+	types := strings.Split(req.URL.Query().Get("type"), ",")
+	data := sortByType(QueryStore.QueryType(types))
+
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusCreated)
+
+	err := json.NewEncoder(writer).Encode(data)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func GetResourcesByProperty(writer http.ResponseWriter, req *http.Request) {
+	query, err := buildQuery(req.URL.Query().Get("property"), true)
+	if err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	res, err := QueryStore.QueryProperty(query)
+	if err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	data := sortByType(res)
+
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusCreated)
+
+	err = json.NewEncoder(writer).Encode(data)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func GetResourcesByLabel(writer http.ResponseWriter, req *http.Request) {
+	query, err := buildQuery(req.URL.Query().Get("label"), false)
+	if err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	res, err := QueryStore.QueryLabel(query)
+	if err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	data := sortByType(res)
+
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusCreated)
+
+	err = json.NewEncoder(writer).Encode(data)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func buildQuery(url string, isProperty bool) (query.Query, error) {
+	params := strings.Split(url, "-")
+
+	if len(params) != 3 { //nolint:gomnd
+		return query.Query{}, ErrNumArgs
+	}
+
+	key := params[0]
+
+	var operator query.Operator
+
+	switch params[1] {
+	case "equal":
+		operator = query.MatchEqual
+	case "notequal":
+		operator = query.MatchNotEqual
+	case "in":
+		operator = query.MatchIn
+	case "notin":
+		operator = query.MatchNotIn
+	}
+
+	values := strings.Split(params[2], ",")
+
+	return query.Query{Op: operator, Key: key, Values: values}, nil
+}
+
+func sortByType(resources []zebra.Resource) map[string][]zebra.Resource {
+	sortedRes := make(map[string][]zebra.Resource)
+
+	for _, res := range resources {
+		resType := res.GetType()
+		sortedRes[resType] = append(sortedRes[resType], res)
+	}
+
+	return sortedRes
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,302 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/rchamarthy/zebra/api"
+	"github.com/stretchr/testify/assert"
+	"gojini.dev/web"
+)
+
+//nolint:gochecknoglobals
+var (
+	handlerAll      = http.HandlerFunc(api.GetResources)
+	handlerID       = http.HandlerFunc(api.GetResourcesByID)
+	handlerType     = http.HandlerFunc(api.GetResourcesByType)
+	handlerProperty = http.HandlerFunc(api.GetResourcesByProperty)
+	handlerLabel    = http.HandlerFunc(api.GetResourcesByLabel)
+)
+
+//nolint:gochecknoglobals
+var (
+	resource1 = `{"VLANPool":[{"id":"0100000001","type":"VLANPool","labels":{"owner":"shravya"},` +
+		`"rangeStart":0,"rangeEnd":10}]}` + "\n"
+	resource2 = `{"VLANPool":[{"id":"0100000002","type":"VLANPool","labels":{"owner":"nandyala"},` +
+		`"rangeStart":1,"rangeEnd":5}]}` + "\n"
+	resources = `{"VLANPool":[{"id":"0100000001","type":"VLANPool","labels":{"owner":"shravya"},` +
+		`"rangeStart":0,"rangeEnd":10},{"id":"0100000002","type":"VLANPool","labels":{"owner":"nandyala"},` +
+		`"rangeStart":1,"rangeEnd":5}]}` + "\n"
+	otherResources = `{"VLANPool":[{"id":"0100000002","type":"VLANPool","labels":{"owner":"nandyala"},` +
+		`"rangeStart":1,"rangeEnd":5},{"id":"0100000001","type":"VLANPool","labels":{"owner":"shravya"},` +
+		`"rangeStart":0,"rangeEnd":10}]}` + "\n"
+	noResources = "{}\n"
+)
+
+func TestSetUp(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	assert.Nil(api.SetUp("teststore"))
+}
+
+func TestGetResources(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	assert.Nil(api.SetUp("teststore"))
+
+	cfg := &web.Config{
+		Address: web.NewAddress("127.0.0.1:9999"),
+		TLS:     nil,
+	}
+
+	server := web.NewServer(cfg, handlerAll)
+	assert.NotNil(server)
+
+	ctx := context.Background()
+
+	go func() {
+		assert.NotNil(server.Start(ctx))
+	}()
+	time.Sleep(time.Second)
+
+	resp, err := http.Get(fmt.Sprintf("http://%s/", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == resources || string(body) == otherResources)
+	assert.Nil(resp.Body.Close())
+
+	assert.Nil(server.Stop(ctx, nil))
+}
+
+func TestGetResourcesByID(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	assert.Nil(api.SetUp("teststore"))
+
+	cfg := &web.Config{
+		Address: web.NewAddress("127.0.0.1:9998"),
+		TLS:     nil,
+	}
+
+	server := web.NewServer(cfg, handlerID)
+	assert.NotNil(server)
+
+	ctx := context.Background()
+
+	go func() {
+		assert.NotNil(server.Start(ctx))
+	}()
+	time.Sleep(time.Second)
+
+	// GET resource1
+	resp, err := http.Get(fmt.Sprintf("http://%s?id=0100000001", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.Equal(string(body), resource1)
+	assert.Nil(resp.Body.Close())
+
+	// GET resource2
+	resp, err = http.Get(fmt.Sprintf("http://%s?id=0100000002", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.Equal(string(body), resource2)
+	assert.Nil(resp.Body.Close())
+
+	// GET resources
+	resp, err = http.Get(fmt.Sprintf("http://%s?id=0100000001,0100000002", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.Equal(string(body), resources)
+	assert.Nil(resp.Body.Close())
+
+	assert.Nil(server.Stop(ctx, nil))
+}
+
+func TestGetResourcesByType(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	assert.Nil(api.SetUp("teststore"))
+
+	cfg := &web.Config{
+		Address: web.NewAddress("127.0.0.1:9997"),
+		TLS:     nil,
+	}
+
+	server := web.NewServer(cfg, handlerType)
+	assert.NotNil(server)
+
+	ctx := context.Background()
+
+	go func() {
+		assert.NotNil(server.Start(ctx))
+	}()
+	time.Sleep(time.Second)
+
+	// GET resources
+	resp, err := http.Get(fmt.Sprintf("http://%s?type=VLANPool", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == resources || string(body) == otherResources)
+	assert.Nil(resp.Body.Close())
+
+	// GET no resources
+	resp, err = http.Get(fmt.Sprintf("http://%s?type=IPAddressPool", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.Equal(string(body), noResources)
+	assert.Nil(resp.Body.Close())
+
+	assert.Nil(server.Stop(ctx, nil))
+}
+
+func TestGetResourcesByProperty(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	assert.Nil(api.SetUp("teststore"))
+
+	cfg := &web.Config{
+		Address: web.NewAddress("127.0.0.1:9996"),
+		TLS:     nil,
+	}
+	server := web.NewServer(cfg, handlerProperty)
+
+	assert.NotNil(server)
+
+	ctx := context.Background()
+
+	go func() {
+		assert.NotNil(server.Start(ctx))
+	}()
+	time.Sleep(time.Second)
+
+	resp, err := http.Get(fmt.Sprintf("http://%s?property=Type-in-VLANPool,IPAddressPool", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == resources || string(body) == otherResources)
+	assert.Nil(resp.Body.Close())
+
+	resp, err = http.Get(fmt.Sprintf("http://%s?property=Type-notin-VLANPool,IPAddressPool", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == noResources)
+	assert.Nil(resp.Body.Close())
+
+	resp, err = http.Get(fmt.Sprintf("http://%s?property=Type-equal-VLANPool", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == resources || string(body) == otherResources)
+	assert.Nil(resp.Body.Close())
+
+	resp, err = http.Get(fmt.Sprintf("http://%s?property=Type-notequal-VLANPool", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == noResources)
+	assert.Nil(resp.Body.Close())
+
+	resp, err = http.Get(fmt.Sprintf("http://%s?property=Type-notequal", cfg.Address))
+	assert.True(err == nil && resp != nil)
+	assert.True(resp.StatusCode == 400)
+	assert.Nil(server.Stop(ctx, nil))
+}
+
+func TestGetResourcesByLabel(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	assert.Nil(api.SetUp("teststore"))
+
+	cfg := &web.Config{
+		Address: web.NewAddress("127.0.0.1:9995"),
+		TLS:     nil,
+	}
+	server := web.NewServer(cfg, handlerLabel)
+	assert.NotNil(server)
+
+	ctx := context.Background()
+
+	go func() {
+		assert.NotNil(server.Start(ctx))
+	}()
+	time.Sleep(time.Second)
+
+	resp, err := http.Get(fmt.Sprintf("http://%s?label=owner-in-shravya,nandyala", cfg.Address))
+	assert.Nil(err)
+	assert.NotNil(resp)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == resources || string(body) == otherResources)
+	assert.Nil(resp.Body.Close())
+
+	resp, err = http.Get(fmt.Sprintf("http://%s?label=owner-notin-shravya,nandyala", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == noResources)
+	assert.Nil(resp.Body.Close())
+
+	resp, err = http.Get(fmt.Sprintf("http://%s?label=owner-equal-shravya", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == resource1)
+	assert.Nil(resp.Body.Close())
+
+	resp, err = http.Get(fmt.Sprintf("http://%s?label=owner-notequal-shravya", cfg.Address))
+	assert.True(err == nil && resp != nil)
+
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Nil(err)
+
+	assert.True(string(body) == resource2)
+	assert.Nil(resp.Body.Close())
+
+	resp, err = http.Get(fmt.Sprintf("http://%s?label=owner-notequal", cfg.Address))
+	assert.True(err == nil && resp != nil)
+	assert.True(resp.StatusCode == 400)
+	assert.Nil(server.Stop(ctx, nil))
+}

--- a/api/teststore/resources/01/00000001
+++ b/api/teststore/resources/01/00000001
@@ -1,0 +1,9 @@
+{
+    "id":"0100000001",
+    "type":"VLANPool",
+    "rangeStart":0,
+    "rangeEnd":10,
+    "labels": {
+        "owner": "shravya"
+    }
+}

--- a/api/teststore/resources/01/00000002
+++ b/api/teststore/resources/01/00000002
@@ -1,0 +1,9 @@
+{
+    "id":"0100000002",
+    "type":"VLANPool",
+    "rangeStart":1,
+    "rangeEnd":5,
+    "labels": {
+        "owner": "nandyala"
+    }
+}

--- a/compute/compute.go
+++ b/compute/compute.go
@@ -31,7 +31,7 @@ type Server struct {
 	Model        string            `json:"model"`
 }
 
-func (s *Server) Validate(ctx context.Context) error {
+func (s Server) Validate(ctx context.Context) error {
 	switch {
 	case s.SerialNumber == "":
 		return ErrSerialEmpty
@@ -56,7 +56,7 @@ type ESX struct {
 	IP          net.IP            `json:"ip"`
 }
 
-func (e *ESX) Validate(ctx context.Context) error {
+func (e ESX) Validate(ctx context.Context) error {
 	if e.IP == nil {
 		return ErrIPEmpty
 	}
@@ -79,7 +79,7 @@ type VCenter struct {
 	IP          net.IP            `json:"ip"`
 }
 
-func (v *VCenter) Validate(ctx context.Context) error {
+func (v VCenter) Validate(ctx context.Context) error {
 	if v.IP == nil {
 		return ErrIPEmpty
 	}
@@ -101,7 +101,7 @@ type VM struct {
 	VCenterID    string            `json:"vCenterID"`    //nolint:tagliatelle
 }
 
-func (v *VM) Validate(ctx context.Context) error {
+func (v VM) Validate(ctx context.Context) error {
 	switch {
 	case v.ESXID == "":
 		return ErrESXEmpty

--- a/dc/dc.go
+++ b/dc/dc.go
@@ -21,7 +21,7 @@ type Datacenter struct {
 
 // Validate returns an error if the given Datacenter object has incorrect values.
 // Else, it returns nil.
-func (dc *Datacenter) Validate(ctx context.Context) error {
+func (dc Datacenter) Validate(ctx context.Context) error {
 	if dc.Address == "" {
 		return ErrAddressEmpty
 	}
@@ -34,6 +34,12 @@ type Lab struct {
 	zebra.NamedResource
 }
 
+// Validate returns an error if the given Datacenter object has incorrect values.
+// Else, it returns nil.
+func (lab Lab) Validate(ctx context.Context) error {
+	return lab.NamedResource.Validate(ctx)
+}
+
 // A Rack represents a datacenter rack. It consists of a name, ID, and associated
 // row.
 type Rack struct {
@@ -43,7 +49,7 @@ type Rack struct {
 
 // Validate returns an error if the given Rack object has incorrect values.
 // Else, it returns nil.
-func (r *Rack) Validate(ctx context.Context) error {
+func (r Rack) Validate(ctx context.Context) error {
 	if r.Row == "" {
 		return ErrRowEmpty
 	}

--- a/dc/dc_test.go
+++ b/dc/dc_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestDatacenter tests the *Datacenter Validate function with a pass and a fail
+// TestDatacenter tests the Datacenter Validate function with a pass and a fail
 // case.
 func TestDatacenter(t *testing.T) {
 	t.Parallel()
@@ -20,14 +20,30 @@ func TestDatacenter(t *testing.T) {
 	datacenter := new(dc.Datacenter)
 	assert.NotNil(datacenter.Validate(ctx))
 
-	datacenter.ID = "abracadabra"
+	datacenter.ID = "test"
 	datacenter.Type = "Datacenter"
 	datacenter.Name = "jasmine"
 	datacenter.Address = "1 palace st, agrabah"
 	assert.Nil(datacenter.Validate(ctx))
 }
 
-// TestRack tests the *Rack Validate function with a pass and a fail case.
+// TestLab tests the Lab Validate function with a pass and a fail
+// case.
+func TestLab(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	ctx := context.Background()
+	lab := new(dc.Lab)
+	assert.NotNil(lab.Validate(ctx))
+
+	lab.ID = "abracadabra"
+	lab.Type = "Lab"
+	lab.Name = "jasmine"
+	assert.Nil(lab.Validate(ctx))
+}
+
+// TestRack tests the Rack Validate function with a pass and a fail case.
 func TestRack(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require github.com/stretchr/testify v1.7.1
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gojini.dev/web v0.0.0-20220611200440-c2f6a400e1e0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gojini.dev/web v0.0.0-20220611200440-c2f6a400e1e0 h1:5/5ezpJMK0ixmMY3V8xO5vU8Us7Z1kGnDd4/dxDDbCE=
+gojini.dev/web v0.0.0-20220611200440-c2f6a400e1e0/go.mod h1:HCVlc70C+IsDcOYEbGtFDvReZzVzMRkbZLQiERs3YO4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/network/network.go
+++ b/network/network.go
@@ -34,7 +34,7 @@ type Switch struct {
 
 // Validate returns an error if the given Switch object has incorrect values.
 // Else, it returns nil.
-func (s *Switch) Validate(ctx context.Context) error {
+func (s Switch) Validate(ctx context.Context) error {
 	switch {
 	case s.ManagementIP == nil:
 		return ErrIPEmpty
@@ -62,7 +62,7 @@ type IPAddressPool struct {
 
 // Validate returns an error if the given IPAddressPool object has incorrect values.
 // Else, it returns nil.
-func (p *IPAddressPool) Validate(ctx context.Context) error {
+func (p IPAddressPool) Validate(ctx context.Context) error {
 	for _, ip := range p.Subnets {
 		if ip.IP == nil {
 			return ErrIPEmpty
@@ -83,7 +83,7 @@ type VLANPool struct {
 
 // Validate returns an error if the given VLANPool object has incorrect values.
 // Else, it returns nil.
-func (v *VLANPool) Validate(ctx context.Context) error {
+func (v VLANPool) Validate(ctx context.Context) error {
 	if v.RangeStart > v.RangeEnd {
 		return ErrInvalidRange
 	}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestSwitch tests the *Switch Validate function with a pass and a fail case.
+// TestSwitch tests the Switch Validate function with a pass and a fail case.
 func TestSwitch(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
@@ -56,7 +56,7 @@ func TestSwitch(t *testing.T) {
 	assert.Nil(switch1.Validate(ctx))
 }
 
-// TestIPAddressPool tests the *IPAddressPool Validate function with a pass and a fail case.
+// TestIPAddressPool tests the IPAddressPool Validate function with a pass and a fail case.
 func TestIPAddressPool(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
@@ -87,7 +87,7 @@ func TestIPAddressPool(t *testing.T) {
 	assert.NotNil(pool.Validate(ctx))
 }
 
-// TestVLANPool tests the *VLANPool Validate function with a pass and a fail case.
+// TestVLANPool tests the VLANPool Validate function with a pass and a fail case.
 func TestVLANPool(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/query/query.go
+++ b/query/query.go
@@ -243,7 +243,7 @@ func (qs *QueryStore) QueryUUID(uuids []string) []zebra.Resource {
 }
 
 // Return resources with matching types.
-func (qs *QueryStore) QueryType(types ...string) []zebra.Resource {
+func (qs *QueryStore) QueryType(types []string) []zebra.Resource {
 	qs.lock.RLock()
 	defer qs.lock.RUnlock()
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -316,11 +316,11 @@ func TestQueryType(t *testing.T) {
 
 	assert.Nil(querystore.Initialize())
 
-	vlanpools := querystore.QueryType("VLANPool")
+	vlanpools := querystore.QueryType([]string{"VLANPool"})
 	assert.True(len(vlanpools) == 1)
 	assert.True(vlanpools[0].GetID() == "0100000001")
 
-	ippools := querystore.QueryType(ipool)
+	ippools := querystore.QueryType([]string{ipool})
 	assert.True(len(ippools) == 1)
 	assert.True(ippools[0].GetID() == "0200000001")
 }

--- a/resource.go
+++ b/resource.go
@@ -42,7 +42,7 @@ type BaseResource struct {
 
 // Validate returns an error if the given BaseResource object has incorrect values.
 // Else, it returns nil.
-func (r *BaseResource) Validate(ctx context.Context) error {
+func (r BaseResource) Validate(ctx context.Context) error {
 	if r.ID == "" {
 		return ErrIDEmpty
 	} else if r.Type == "" {
@@ -53,17 +53,17 @@ func (r *BaseResource) Validate(ctx context.Context) error {
 }
 
 // Return ID of BaseResource r.
-func (r *BaseResource) GetID() string {
+func (r BaseResource) GetID() string {
 	return r.ID
 }
 
 // BaseResource has no name. Return empty string.
-func (r *BaseResource) GetType() string {
+func (r BaseResource) GetType() string {
 	return r.Type
 }
 
 // Return labels of BaseResource r.
-func (r *BaseResource) GetLabels() Labels {
+func (r BaseResource) GetLabels() Labels {
 	dest := make(Labels, len(r.Labels))
 	for key, val := range r.Labels {
 		dest[key] = val
@@ -98,7 +98,7 @@ type Credentials struct {
 
 // Validate returns an error if the given Credentials object has incorrect values.
 // Else, it returns nil.
-func (c *Credentials) Validate(ctx context.Context) error {
+func (c Credentials) Validate(ctx context.Context) error {
 	keyValidators := map[string]func(string) error{"password": ValidatePassword, "ssh-key": ValidateSSHKey}
 
 	for keyType, key := range c.Keys {

--- a/resource_test.go
+++ b/resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestBaseResource tests the *BaseResource Validate function with a pass case
+// TestBaseResource tests the BaseResource Validate function with a pass case
 // and a fail case.
 func TestBaseResource(t *testing.T) {
 	t.Parallel()
@@ -34,7 +34,7 @@ func TestBaseResource(t *testing.T) {
 	assert.True(res.GetLabels().HasKey("key"))
 }
 
-// TestBaseResource tests the *NamedResource Validate function with a pass case
+// TestBaseResource tests the NamedResource Validate function with a pass case
 // and a fail case.
 func TestNamedResource(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
1. modified resource.go and resource structs to implemen zebra.Resource (before, resource pointers were implementing zebra.Resource)
2. modified store.go and query.go to reflect these changes
3. wrote GET handlers in api.go with tests in api_test.go
4. added two test json files in api/teststore/resources/01 for api_test.go
5. removed storedResource struct in store.go, now JSON files directly store resource because each resource has a type field which is checked when loading from files.

Signed-off-by: Shravya Nandyala <shravya.nandyala@gmail.com>