### PR TITLE
formalize type factory usage

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -12,27 +12,24 @@ import (
 )
 
 type ResourceAPI struct {
-	types      map[string]func() zebra.Resource
+	factory    zebra.ResourceFactory
 	resStore   *store.FileStore
 	queryStore *query.QueryStore
 }
 
 var ErrNumArgs = errors.New("wrong number of args")
 
-func NewResourceAPI(types map[string]func() zebra.Resource) *ResourceAPI {
-	api := new(ResourceAPI)
-	api.types = make(map[string]func() zebra.Resource, len(types))
-
-	for key, val := range types {
-		api.types[key] = val
+func NewResourceAPI(factory zebra.ResourceFactory) *ResourceAPI {
+	return &ResourceAPI{
+		factory:    factory,
+		resStore:   nil,
+		queryStore: nil,
 	}
-
-	return api
 }
 
 // Set up store and query store given storage root.
 func (api *ResourceAPI) Initialize(storageRoot string) error {
-	api.resStore = store.NewFileStore(storageRoot, api.types)
+	api.resStore = store.NewFileStore(storageRoot, api.factory)
 
 	err := api.resStore.Initialize()
 	if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -41,9 +41,7 @@ func TestInitialize(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := map[string]func() zebra.Resource{
-		"VLANPool": func() zebra.Resource { return new(network.VLANPool) },
-	}
+	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
 
 	api := api.NewResourceAPI(f)
 	assert.Nil(api.Initialize("teststore"))
@@ -53,9 +51,7 @@ func TestGetResources(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := map[string]func() zebra.Resource{
-		"VLANPool": func() zebra.Resource { return new(network.VLANPool) },
-	}
+	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
 
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
@@ -91,10 +87,7 @@ func TestGetResourcesByID(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := map[string]func() zebra.Resource{
-		"VLANPool": func() zebra.Resource { return new(network.VLANPool) },
-	}
-
+	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 
@@ -150,10 +143,7 @@ func TestGetResourcesByType(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := map[string]func() zebra.Resource{
-		"VLANPool": func() zebra.Resource { return new(network.VLANPool) },
-	}
-
+	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 
@@ -199,10 +189,7 @@ func TestGetResourcesByProperty(t *testing.T) { // nolint:funlen
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := map[string]func() zebra.Resource{
-		"VLANPool": func() zebra.Resource { return new(network.VLANPool) },
-	}
-
+	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 
@@ -267,10 +254,7 @@ func TestGetResourcesByLabel(t *testing.T) { // nolint:funlen
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := map[string]func() zebra.Resource{
-		"VLANPool": func() zebra.Resource { return new(network.VLANPool) },
-	}
-
+	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -26,7 +26,7 @@ func TestNewQueryStore(t *testing.T) {
 	resource1.RangeStart = 0
 	resource1.RangeEnd = 10
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	// Add resources to map
@@ -48,7 +48,7 @@ func TestInitialize(t *testing.T) {
 	resource1.RangeStart = 0
 	resource1.RangeEnd = 10
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	// Add resources to map
@@ -72,7 +72,7 @@ func TestWipe(t *testing.T) {
 	resource1.RangeStart = 0
 	resource1.RangeEnd = 10
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	// Add resources to map
@@ -101,7 +101,7 @@ func TestClear(t *testing.T) {
 	resource1.RangeStart = 0
 	resource1.RangeEnd = 10
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	// Add resources to map
@@ -141,7 +141,7 @@ func TestCreateAndUpdate(t *testing.T) {
 	resource2.RangeStart = 1
 	resource2.RangeEnd = 5
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	// Add resources to map
@@ -203,7 +203,7 @@ func TestDelete(t *testing.T) {
 	resource2.RangeStart = 1
 	resource2.RangeEnd = 5
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	// Add resources to map
@@ -247,7 +247,7 @@ func TestQuery(t *testing.T) {
 	mask := ip.DefaultMask()
 	resource2.Subnets = []net.IPNet{{IP: ip, Mask: mask}}
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 	f.Add(ipool, func() zebra.Resource { return new(network.IPAddressPool) })
 
@@ -286,7 +286,7 @@ func TestQueryUUID(t *testing.T) {
 	mask := ip.DefaultMask()
 	resource2.Subnets = []net.IPNet{{IP: ip, Mask: mask}}
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 	f.Add(ipool, func() zebra.Resource { return new(network.IPAddressPool) })
 
@@ -329,7 +329,7 @@ func TestQueryType(t *testing.T) {
 	mask := ip.DefaultMask()
 	resource2.Subnets = []net.IPNet{{IP: ip, Mask: mask}}
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 	f.Add(ipool, func() zebra.Resource { return new(network.IPAddressPool) })
 
@@ -364,7 +364,7 @@ func TestInvalidLabelQuery(t *testing.T) {
 	resource1.RangeStart = 0
 	resource1.RangeEnd = 10
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	// Add resources to map
@@ -422,7 +422,7 @@ func TestQueryLabel(t *testing.T) {
 
 	resource1, resource2 := getResources()
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 	f.Add(ipool, func() zebra.Resource { return new(network.IPAddressPool) })
 
@@ -472,7 +472,7 @@ func TestQueryProperty(t *testing.T) {
 
 	resource1, resource2 := getResources()
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 	f.Add(ipool, func() zebra.Resource { return new(network.IPAddressPool) })
 

--- a/resmap.go
+++ b/resmap.go
@@ -9,19 +9,10 @@ type ResourceFactory interface {
 	Add(resourceType string, factory func() Resource) ResourceFactory
 }
 
-type FunctionMap struct {
-	types map[string]func() Resource
-}
+type typeMap map[string]func() Resource
 
-func NewFunctionMap() *FunctionMap {
-	funMap := new(FunctionMap)
-	funMap.types = make(map[string]func() Resource)
-
-	return funMap
-}
-
-func (f *FunctionMap) New(resourceType string) Resource {
-	factory, ok := f.types[resourceType]
+func (t typeMap) New(resourceType string) Resource {
+	factory, ok := t[resourceType]
 	if !ok {
 		return nil
 	}
@@ -31,14 +22,14 @@ func (f *FunctionMap) New(resourceType string) Resource {
 
 // Add adds a type and its factory method to the resource factory and returns the resource factory.
 // The returned resource factory object can be used to add more types in a chained fashion.
-func (f *FunctionMap) Add(resourceType string, factory func() Resource) ResourceFactory {
-	f.types[resourceType] = factory
+func (t typeMap) Add(resourceType string, factory func() Resource) ResourceFactory {
+	t[resourceType] = factory
 
-	return f
+	return t
 }
 
 func Factory() ResourceFactory {
-	return &FunctionMap{types: map[string]func() Resource{}}
+	return typeMap{}
 }
 
 type ResourceList struct {

--- a/resmap_test.go
+++ b/resmap_test.go
@@ -8,30 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewFunctionMap(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
-
-	assert.NotNil(zebra.NewFunctionMap())
-}
-
 func TestAddNew(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	assert.NotNil(f)
 
 	f.Add("Switch", func() zebra.Resource { return new(network.Switch) })
 	assert.NotNil(f.New("Switch"))
 	assert.Nil(f.New("random"))
-}
-
-func TestFactory(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
-
-	assert.NotNil(zebra.Factory())
 }
 
 func TestNewResourceList(t *testing.T) {
@@ -62,7 +48,7 @@ func TestListMarshalUnMarshal(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	funMap := zebra.NewFunctionMap()
+	funMap := zebra.Factory()
 	funMap.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
 
 	resA := zebra.NewResourceList(funMap)
@@ -133,7 +119,7 @@ func TestGetFactory(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := zebra.NewFunctionMap()
+	f := zebra.Factory()
 	f.Add("Switch", func() zebra.Resource { return new(network.Switch) })
 
 	resA := zebra.NewResourceMap(f)
@@ -146,7 +132,7 @@ func TestAdd(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	funMap := zebra.NewFunctionMap()
+	funMap := zebra.Factory()
 	funMap.Add("Switch", func() zebra.Resource { return new(network.Switch) })
 
 	resA := zebra.NewResourceMap(funMap)
@@ -162,7 +148,7 @@ func TestDelete(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	funMap := zebra.NewFunctionMap()
+	funMap := zebra.Factory()
 	funMap.Add("Switch", func() zebra.Resource { return new(network.Switch) })
 
 	resA := zebra.NewResourceMap(funMap)
@@ -181,7 +167,7 @@ func TestMapMarshalUnMarshal(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	funMap := zebra.NewFunctionMap()
+	funMap := zebra.Factory()
 	funMap.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
 
 	resA := zebra.NewResourceMap(funMap)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -39,9 +39,8 @@ func TestCreate(t *testing.T) {
 	resource.RangeStart = 0
 	resource.RangeEnd = 10
 
-	types := make(map[string]func() zebra.Resource)
-
-	types[vlan] = func() zebra.Resource { return new(network.VLANPool) }
+	types := zebra.Factory()
+	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	filestore := store.NewFileStore("teststore1", types)
 
@@ -71,9 +70,8 @@ func TestUpdate(t *testing.T) {
 	resource.RangeStart = 0
 	resource.RangeEnd = 10
 
-	types := make(map[string]func() zebra.Resource)
-
-	types[vlan] = func() zebra.Resource { return new(network.VLANPool) }
+	types := zebra.Factory()
+	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	filestore := store.NewFileStore("teststore6", types)
 
@@ -123,9 +121,8 @@ func TestLoad(t *testing.T) {
 	resource.RangeStart = 0
 	resource.RangeEnd = 10
 
-	types := make(map[string]func() zebra.Resource)
-
-	types[vlan] = func() zebra.Resource { return new(network.VLANPool) }
+	types := zebra.Factory()
+	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	filestore := store.NewFileStore("teststore2", types)
 
@@ -163,9 +160,8 @@ func TestDelete(t *testing.T) {
 	resource.RangeStart = 0
 	resource.RangeEnd = 10
 
-	types := make(map[string]func() zebra.Resource)
-
-	types[vlan] = func() zebra.Resource { return new(network.VLANPool) }
+	types := zebra.Factory()
+	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	filestore := store.NewFileStore("teststore3", types)
 
@@ -208,9 +204,8 @@ func TestClearStore(t *testing.T) {
 	resource2.RangeStart = 0
 	resource2.RangeEnd = 10
 
-	types := make(map[string]func() zebra.Resource)
-
-	types[vlan] = func() zebra.Resource { return new(network.VLANPool) }
+	types := zebra.Factory()
+	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
 
 	filestore := store.NewFileStore("teststore4", types)
 


### PR DESCRIPTION
current code uses the types map instead of the ResourceFactory
interface. we need to consistently use the ResourceFactory interface
everywhere we need a factory for producing a resource based on its type
name.

Signed-off-by: Ravi Chamarthy <ravi@chamarthy.dev>